### PR TITLE
Prepare for packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 *.py[co]
+
+/build/
+/dist/
+/dockerize.egg-info/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/README.rst
+++ b/README.rst
@@ -1,13 +1,17 @@
-# Dockerize
+Dockerize
+=========
 
 Dockerize will pack up your dynamically linked ELF binaries and all
 their dependencies and turn them into a Docker image.
 
 Some example images built with this tool are available from:
 
-- https://hub.docker.com/u/dockerizeme/
+-  https://hub.docker.com/u/dockerizeme/
 
-## Synopsis
+Synopsis
+--------
+
+::
 
     usage: dockerize [-h] [--tag TAG] [--cmd CMD] [--entrypoint ENTRYPOINT]
                      [--no-build] [--output-dir OUTPUT_DIR] [--add-file SRC DST]
@@ -40,20 +44,28 @@ Some example images built with this tool are available from:
       --verbose
       --debug
 
-## A simple example
+A simple example
+----------------
 
-Create a `sed` image:
+Create a ``sed`` image:
+
+::
 
     dockerize -t sed /bin/sed
 
 Use it:
 
+::
+
     $ echo hello world | docker run -i sed s/world/jupiter
     hello jupiter
 
-## A more complicated example
+A more complicated example
+--------------------------
 
-Create an image named `thttpd`:
+Create an image named ``thttpd``:
+
+::
 
     dockerize -t thttpd \
       -a /var/www/thttpd /var/www \
@@ -63,9 +75,13 @@ Create an image named `thttpd`:
 
 Serve default content:
 
+::
+
     docker run thttpd
 
 Serve your own content:
+
+::
 
     docker run -v /my/content:/var/www thttpd
 

--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,16 @@ Some example images built with this tool are available from:
 
 -  https://hub.docker.com/u/dockerizeme/
 
+Installation
+------------
+
+You can install the latest development version of ``dockerize`` with the
+following command:
+
+::
+
+    pip install --user git+http://github.com/larsks/dockerize.git
+
 Synopsis
 --------
 

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ their dependencies and turn them into a Docker image.
 
 Some example images built with this tool are available from:
 
--  https://hub.docker.com/u/dockerizeme/
+- https://hub.docker.com/u/dockerizeme/
 
 Installation
 ------------

--- a/dockerize/__init__.py
+++ b/dockerize/__init__.py
@@ -1,4 +1,4 @@
 __program__ = 'dockerize'
-__version__ = '0.2'
+__version__ = '0.2.1'
 __description__ = 'A tool for creating minimal docker ' \
                   'images from dynamic ELF binaries.'

--- a/dockerize/__init__.py
+++ b/dockerize/__init__.py
@@ -1,4 +1,4 @@
 __program__ = 'dockerize'
-__version__ = '0.2.1'
+__version__ = '0.2.2'
 __description__ = 'A tool for creating minimal docker ' \
                   'images from dynamic ELF binaries.'

--- a/dockerize/__init__.py
+++ b/dockerize/__init__.py
@@ -1,2 +1,4 @@
+__program__ = 'dockerize'
 __version__ = '0.2'
-
+__description__ = 'A tool for creating minimal docker ' \
+                  'images from dynamic ELF binaries.'

--- a/dockerize/depsolver.py
+++ b/dockerize/depsolver.py
@@ -68,7 +68,7 @@ class DepSolver(object):
 
     '''Finds shared library dependencies of ELF binaries.'''
 
-    def __init__(self, arch=None):
+    def __init__(self):
         self.deps = set()
 
     def get_deps(self, path):

--- a/dockerize/depsolver.py
+++ b/dockerize/depsolver.py
@@ -1,3 +1,6 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
 import logging
 import os
 import re

--- a/dockerize/depsolver.py
+++ b/dockerize/depsolver.py
@@ -8,12 +8,13 @@ import subprocess
 from collections import namedtuple
 
 LOG = logging.getLogger(__name__)
+
 RE_DEPS = [
     re.compile('''\s+ (?P<name>\S+) \s+ => \s+
                (?P<path>\S+) \s+ \((?P<address>0x[0-9a-f]+)\)''',
                re.VERBOSE),
     re.compile('''(?P<path>\S+) \s+ \((?P<address>0x[0-9a-f]+)\)''',
-               re.VERBOSE),
+               re.VERBOSE)
     ]
 
 ELFContents = namedtuple('ELFContents',
@@ -24,11 +25,12 @@ ELFContents = namedtuple('ELFContents',
                              'vma',
                              'lma',
                              'offset',
-                             'aligment',
+                             'aligment'
                          ])
 
 
-class ELFFile (dict):
+class ELFFile(dict):
+
     def __init__(self, path):
         self.path = path
         self.read_sections()
@@ -50,8 +52,7 @@ class ELFFile (dict):
             self[contents.name] = contents
 
     def section(self, name):
-        '''Return the raw content of the named section from the ELF
-        file.'''
+        '''Return the raw content of the named section from the ELF file.'''
         section = self[name]
         with open(self.path) as fd:
             fd.seek(int(section.offset, base=16))
@@ -63,7 +64,8 @@ class ELFFile (dict):
         return self.section('.interp').rstrip('\0')
 
 
-class DepSolver (object):
+class DepSolver(object):
+
     '''Finds shared library dependencies of ELF binaries.'''
 
     def __init__(self, arch=None):

--- a/dockerize/depsolver.py
+++ b/dockerize/depsolver.py
@@ -54,9 +54,9 @@ class ELFFile(dict):
     def section(self, name):
         '''Return the raw content of the named section from the ELF file.'''
         section = self[name]
-        with open(self.path) as fd:
-            fd.seek(int(section.offset, base=16))
-            data = fd.read(int(section.size, base=16))
+        with open(self.path) as fde:
+            fde.seek(int(section.offset, base=16))
+            data = fde.read(int(section.size, base=16))
             return data
 
     def interpreter(self):
@@ -78,8 +78,8 @@ class DepSolver(object):
         # section.  We need this because we use the dynamic loader
         # to produce the list of library dependencies.
         try:
-            ef = ELFFile(path)
-            interp = ef.interpreter()
+            elf = ELFFile(path)
+            interp = elf.interpreter()
         except ValueError:
             LOG.debug('%s is not a dynamically linked ELF binary (ignoring)',
                       path)

--- a/dockerize/depsolver.py
+++ b/dockerize/depsolver.py
@@ -10,10 +10,10 @@ from collections import namedtuple
 LOG = logging.getLogger(__name__)
 
 RE_DEPS = [
-    re.compile('''\s+ (?P<name>\S+) \s+ => \s+
+    re.compile(r'''\s+ (?P<name>\S+) \s+ => \s+
                (?P<path>\S+) \s+ \((?P<address>0x[0-9a-f]+)\)''',
                re.VERBOSE),
-    re.compile('''(?P<path>\S+) \s+ \((?P<address>0x[0-9a-f]+)\)''',
+    re.compile(r'''(?P<path>\S+) \s+ \((?P<address>0x[0-9a-f]+)\)''',
                re.VERBOSE)
     ]
 

--- a/dockerize/dockerize.py
+++ b/dockerize/dockerize.py
@@ -1,3 +1,6 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
 import glob
 import grp
 import json

--- a/dockerize/dockerize.py
+++ b/dockerize/dockerize.py
@@ -185,7 +185,7 @@ class Dockerize(object):
         subprocess.check_call(cmd)
 
     def resolve_deps(self):
-        '''Uses the dockerize.DepSolver class to find all the shared
+        '''Uses the dockerize.depsolver.DepSolver class to find all the shared
         library dependencies of files installed into the Docker image.'''
 
         deps = DepSolver()

--- a/dockerize/dockerize.py
+++ b/dockerize/dockerize.py
@@ -132,9 +132,9 @@ class Dockerize(object):
     def generate_dockerfile(self):
         LOG.info('generating Dockerfile')
         tmpl = self.env.get_template('Dockerfile')
-        with open(os.path.join(self.targetdir, 'Dockerfile'), 'w') as fd:
-            fd.write(tmpl.render(controller=self,
-                                 docker=self.docker))
+        with open(os.path.join(self.targetdir, 'Dockerfile'), 'w') as fde:
+            fde.write(tmpl.render(controller=self,
+                                  docker=self.docker))
 
     def makedirs(self, path):
         if not os.path.isdir(path):
@@ -149,11 +149,11 @@ class Dockerize(object):
         self.makedirs(os.path.join(self.targetdir, 'etc'))
         for path in ['passwd', 'group', 'nsswitch.conf']:
             tmpl = self.env.get_template(path)
-            with open(os.path.join(self.targetdir, 'etc', path), 'w') as fd:
-                fd.write(tmpl.render(controller=self,
-                                     docker=self.docker,
-                                     users=self.users,
-                                     groups=self.groups))
+            with open(os.path.join(self.targetdir, 'etc', path), 'w') as fde:
+                fde.write(tmpl.render(controller=self,
+                                      docker=self.docker,
+                                      users=self.users,
+                                      groups=self.groups))
 
     def copy_file(self, src, dst=None, symlinks=None):
         '''Copy a file into the image.  This uses "rsync" to perform the
@@ -194,7 +194,7 @@ class Dockerize(object):
         deps = DepSolver()
 
         # Iterate over all files in the image.
-        for root, dirs, files in os.walk(self.targetdir):
+        for root, _, files in os.walk(self.targetdir):
             for name in files:
                 path = os.path.join(root, name)
                 deps.add(path)

--- a/dockerize/dockerize.py
+++ b/dockerize/dockerize.py
@@ -11,20 +11,22 @@ import shlex
 import shutil
 import subprocess
 import tempfile
-from jinja2 import Environment, PackageLoader
 from depsolver import DepSolver
+from jinja2 import Environment, PackageLoader
 
 LOG = logging.getLogger(__name__)
 
+
 # Link handling constants
-class symlink_options (object):
+class symlink_options(object):
     PRESERVE = 1
     COPY_UNSAFE = 2
     SKIP_UNSAFE = 3
     COPY_ALL = 4
 
 
-class Dockerize (object):
+class Dockerize(object):
+
     def __init__(self,
                  cmd=None,
                  entrypoint=None,
@@ -85,7 +87,7 @@ class Dockerize (object):
         image.'''
 
         if dst is None:
-            dst=src
+            dst = src
 
         if not dst.startswith('/'):
             raise ValueError('%s: container paths must be fully '

--- a/dockerize/dockerize.py
+++ b/dockerize/dockerize.py
@@ -20,7 +20,7 @@ LOG = logging.getLogger(__name__)
 
 
 # Link handling constants
-class symlink_options(object):
+class SymlinkOptions(object):
     PRESERVE = 1
     COPY_UNSAFE = 2
     SKIP_UNSAFE = 3
@@ -34,7 +34,7 @@ class Dockerize(object):
                  entrypoint=None,
                  targetdir=None,
                  tag=None,
-                 symlinks=symlink_options.PRESERVE,
+                 symlinks=SymlinkOptions.PRESERVE,
                  build=True):
 
         self.docker = {}
@@ -174,11 +174,11 @@ class Dockerize(object):
 
         # Add flag to rsync command line corresponding to the select
         # symlink handling method.
-        if symlinks == symlink_options.COPY_ALL:
+        if symlinks == SymlinkOptions.COPY_ALL:
             cmd.append('-L')
-        elif symlinks == symlink_options.COPY_UNSAFE:
+        elif symlinks == SymlinkOptions.COPY_UNSAFE:
             cmd.append('--copy-unsafe-links')
-        elif symlinks == symlink_options.SKIP_UNSAFE:
+        elif symlinks == SymlinkOptions.SKIP_UNSAFE:
             cmd.append('--safe-links')
 
         cmd += [src, target]
@@ -199,7 +199,7 @@ class Dockerize(object):
                 deps.add(path)
 
         for src in deps.deps:
-            self.copy_file(src, symlinks=symlink_options.COPY_ALL)
+            self.copy_file(src, symlinks=SymlinkOptions.COPY_ALL)
 
         # Install some basic nss libraries to permit programs to resolve
         # users, groups, and hosts.
@@ -210,7 +210,7 @@ class Dockerize(object):
                 src = os.path.join(libdir, nsslib)
                 LOG.info('looking for %s', src)
                 if os.path.exists(src):
-                    self.copy_file(src, symlinks=symlink_options.COPY_ALL)
+                    self.copy_file(src, symlinks=SymlinkOptions.COPY_ALL)
 
     def copy_files(self):
         '''Process the list of paths generated via add_file and copy items

--- a/dockerize/dockerize.py
+++ b/dockerize/dockerize.py
@@ -1,6 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import
+
 import glob
 import grp
 import json
@@ -11,7 +13,7 @@ import shlex
 import shutil
 import subprocess
 import tempfile
-from .depsolver import DepSolver
+from dockerize.depsolver import DepSolver
 from jinja2 import Environment, PackageLoader
 
 LOG = logging.getLogger(__name__)

--- a/dockerize/dockerize.py
+++ b/dockerize/dockerize.py
@@ -16,7 +16,7 @@ import tempfile
 
 from jinja2 import Environment, PackageLoader
 
-from dockerize.depsolver import DepSolver
+from .depsolver import DepSolver
 
 LOG = logging.getLogger(__name__)
 

--- a/dockerize/dockerize.py
+++ b/dockerize/dockerize.py
@@ -13,8 +13,10 @@ import shlex
 import shutil
 import subprocess
 import tempfile
-from dockerize.depsolver import DepSolver
+
 from jinja2 import Environment, PackageLoader
+
+from dockerize.depsolver import DepSolver
 
 LOG = logging.getLogger(__name__)
 

--- a/dockerize/dockerize.py
+++ b/dockerize/dockerize.py
@@ -11,7 +11,7 @@ import shlex
 import shutil
 import subprocess
 import tempfile
-from depsolver import DepSolver
+from .depsolver import DepSolver
 from jinja2 import Environment, PackageLoader
 
 LOG = logging.getLogger(__name__)

--- a/dockerize/dockerize.py
+++ b/dockerize/dockerize.py
@@ -112,8 +112,7 @@ class Dockerize(object):
                 self.targetdir = tempfile.mkdtemp(prefix='dockerize')
                 cleanup = True
             else:
-                LOG.warn('writing output to %s',
-                         self.targetdir)
+                LOG.warning('writing output to %s', self.targetdir)
                 if not os.path.isdir(self.targetdir):
                     os.mkdir(self.targetdir)
 

--- a/dockerize/main.py
+++ b/dockerize/main.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import,print_function
+from __future__ import absolute_import, print_function
 
 import argparse
 import glob
@@ -10,14 +10,12 @@ import os
 import sys
 
 from dockerize import __version__
-from .dockerize import (
-    symlink_options,
-    Dockerize,
-)
+from .dockerize import Dockerize, symlink_options
 
 
 LOG = logging.getLogger(__name__)
-FILETOOLS  = [
+
+FILETOOLS = [
     '/bin/ls',
     '/bin/mkdir',
     '/bin/chmod',
@@ -77,13 +75,14 @@ def parse_args():
                    action='store_const',
                    const=logging.DEBUG,
                    dest='loglevel')
-    
+
     p.add_argument('--version',
                    action='store_true')
     p.add_argument('paths', nargs=argparse.REMAINDER)
     p.set_defaults(loglevel=logging.WARN)
 
     return p.parse_args()
+
 
 def main():
     args = parse_args()
@@ -96,7 +95,7 @@ def main():
 
     try:
         args.symlinks = getattr(symlink_options, '%s' %
-                                args.symlinks.upper().replace('-','_'))
+                                args.symlinks.upper().replace('-', '_'))
     except AttributeError:
         LOG.error('%s: invalid symlink mode', args.symlinks)
         sys.exit(1)
@@ -131,6 +130,7 @@ def main():
         app.add_group(group)
 
     app.build()
+
 
 if __name__ == '__main__':
     main()

--- a/dockerize/main.py
+++ b/dockerize/main.py
@@ -8,7 +8,7 @@ import logging
 import os
 import sys
 
-from dockerize import __description__, __program__, __version__
+from . import __description__, __program__, __version__
 from .dockerize import Dockerize, symlink_options
 
 

--- a/dockerize/main.py
+++ b/dockerize/main.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import
 
 import argparse
 import logging

--- a/dockerize/main.py
+++ b/dockerize/main.py
@@ -8,7 +8,7 @@ import logging
 import os
 import sys
 
-from dockerize import __version__
+from dockerize import __description__, __version__
 from .dockerize import Dockerize, symlink_options
 
 
@@ -27,7 +27,8 @@ FILETOOLS = [
 
 
 def parse_args():
-    p = argparse.ArgumentParser()
+    p = argparse.ArgumentParser(
+        description=__description__)
 
     g = p.add_argument_group('Docker options')
     g.add_argument('--tag', '-t',

--- a/dockerize/main.py
+++ b/dockerize/main.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import, print_function
 
 import argparse
 import logging
-import os
 import sys
 
 from . import __description__, __program__, __version__

--- a/dockerize/main.py
+++ b/dockerize/main.py
@@ -7,9 +7,8 @@ import argparse
 import logging
 import sys
 
-from dockerize import __description__, __program__, __version__
-from dockerize.dockerize import Dockerize, SymlinkOptions
-
+from . import __description__, __program__, __version__
+from .dockerize import Dockerize, SymlinkOptions
 
 LOG = logging.getLogger(__name__)
 

--- a/dockerize/main.py
+++ b/dockerize/main.py
@@ -4,7 +4,6 @@
 from __future__ import absolute_import, print_function
 
 import argparse
-import glob
 import logging
 import os
 import sys

--- a/dockerize/main.py
+++ b/dockerize/main.py
@@ -26,62 +26,61 @@ FILETOOLS = [
 
 
 def parse_args():
-    p = argparse.ArgumentParser(
-        description=__description__)
+    parser = argparse.ArgumentParser(description=__description__)
 
-    g = p.add_argument_group('Docker options')
-    g.add_argument('--tag', '-t',
-                   help='Tag to apply to Docker image')
-    g.add_argument('--cmd', '-c')
-    g.add_argument('--entrypoint', '-e')
+    group = parser.add_argument_group('Docker options')
+    group.add_argument('--tag', '-t',
+                       help='Tag to apply to Docker image')
+    group.add_argument('--cmd', '-c')
+    group.add_argument('--entrypoint', '-e')
 
-    g = p.add_argument_group('Output options')
-    g.add_argument('--no-build', '-n',
-                   action='store_true',
-                   help='Do not build Docker image')
-    g.add_argument('--output-dir', '-o')
+    group = parser.add_argument_group('Output options')
+    group.add_argument('--no-build', '-n',
+                       action='store_true',
+                       help='Do not build Docker image')
+    group.add_argument('--output-dir', '-o')
 
-    p.add_argument('--add-file', '-a',
-                   metavar=('SRC', 'DST'),
-                   nargs=2,
-                   action='append',
-                   default=[],
-                   help='Add file <src> to image at <dst>')
+    parser.add_argument('--add-file', '-a',
+                        metavar=('SRC', 'DST'),
+                        nargs=2,
+                        action='append',
+                        default=[],
+                        help='Add file <src> to image at <dst>')
 
-    p.add_argument('--symlinks', '-L',
-                   default='copy-unsafe',
-                   help='One of preserve, copy-unsafe, '
-                   'skip-unsafe, copy-all')
-    p.add_argument('--user', '-u',
-                   action='append',
-                   default=[],
-                   help='Add user to /etc/passwd in image')
-    p.add_argument('--group', '-g',
-                   action='append',
-                   default=[],
-                   help='Add group to /etc/group in image')
+    parser.add_argument('--symlinks', '-L',
+                        default='copy-unsafe',
+                        help='One of preserve, copy-unsafe, '
+                        'skip-unsafe, copy-all')
+    parser.add_argument('--user', '-u',
+                        action='append',
+                        default=[],
+                        help='Add user to /etc/passwd in image')
+    parser.add_argument('--group', '-g',
+                        action='append',
+                        default=[],
+                        help='Add group to /etc/group in image')
 
-    p.add_argument('--filetools',
-                   action='store_true',
-                   help='Add common file manipulation tools')
+    parser.add_argument('--filetools',
+                        action='store_true',
+                        help='Add common file manipulation tools')
 
-    g = p.add_argument_group('Logging options')
-    g.add_argument('--verbose',
-                   action='store_const',
-                   const=logging.INFO,
-                   dest='loglevel')
-    g.add_argument('--debug',
-                   action='store_const',
-                   const=logging.DEBUG,
-                   dest='loglevel')
+    group = parser.add_argument_group('Logging options')
+    group.add_argument('--verbose',
+                       action='store_const',
+                       const=logging.INFO,
+                       dest='loglevel')
+    group.add_argument('--debug',
+                       action='store_const',
+                       const=logging.DEBUG,
+                       dest='loglevel')
 
-    p.add_argument('--version',
-                   action='version',
-                   version='{0} version {1}'.format(__program__, __version__))
-    p.add_argument('paths', nargs=argparse.REMAINDER)
-    p.set_defaults(loglevel=logging.WARN)
+    parser.add_argument('--version',
+                        action='version',
+                        version='%s version %s' % (__program__, __version__))
+    parser.add_argument('paths', nargs=argparse.REMAINDER)
+    parser.set_defaults(loglevel=logging.WARN)
 
-    return p.parse_args()
+    return parser.parse_args()
 
 
 def main():

--- a/dockerize/main.py
+++ b/dockerize/main.py
@@ -75,7 +75,7 @@ def parse_args():
 
     parser.add_argument('--version',
                         action='version',
-                        version='%s version %s' % (__program__, __version__))
+                        version='%(prog)s version %s' % __version__)
     parser.add_argument('paths', nargs=argparse.REMAINDER)
     parser.set_defaults(loglevel=logging.WARN)
 
@@ -87,7 +87,7 @@ def main():
     logging.basicConfig(level=args.loglevel)
 
     try:
-        args.symlinks = getattr(SymlinkOptions, '%s' %
+        args.symlinks = getattr(SymlinkOptions,
                                 args.symlinks.upper().replace('-', '_'))
     except AttributeError:
         LOG.error('%s: invalid symlink mode', args.symlinks)

--- a/dockerize/main.py
+++ b/dockerize/main.py
@@ -8,7 +8,7 @@ import logging
 import sys
 
 from dockerize import __description__, __program__, __version__
-from dockerize.dockerize import Dockerize, symlink_options
+from dockerize.dockerize import Dockerize, SymlinkOptions
 
 
 LOG = logging.getLogger(__name__)
@@ -89,7 +89,7 @@ def main():
     logging.basicConfig(level=args.loglevel)
 
     try:
-        args.symlinks = getattr(symlink_options, '%s' %
+        args.symlinks = getattr(SymlinkOptions, '%s' %
                                 args.symlinks.upper().replace('-', '_'))
     except AttributeError:
         LOG.error('%s: invalid symlink mode', args.symlinks)

--- a/dockerize/main.py
+++ b/dockerize/main.py
@@ -8,7 +8,7 @@ import logging
 import os
 import sys
 
-from dockerize import __description__, __version__
+from dockerize import __description__, __program__, __version__
 from .dockerize import Dockerize, symlink_options
 
 
@@ -77,7 +77,8 @@ def parse_args():
                    dest='loglevel')
 
     p.add_argument('--version',
-                   action='store_true')
+                   action='version',
+                   version='{0} version {1}'.format(__program__, __version__))
     p.add_argument('paths', nargs=argparse.REMAINDER)
     p.set_defaults(loglevel=logging.WARN)
 
@@ -87,11 +88,6 @@ def parse_args():
 def main():
     args = parse_args()
     logging.basicConfig(level=args.loglevel)
-
-    if args.version:
-        print(os.path.basename(sys.argv[0]),
-              'version', __version__)
-        sys.exit(0)
 
     try:
         args.symlinks = getattr(symlink_options, '%s' %

--- a/dockerize/main.py
+++ b/dockerize/main.py
@@ -7,8 +7,8 @@ import argparse
 import logging
 import sys
 
-from . import __description__, __program__, __version__
-from .dockerize import Dockerize, symlink_options
+from dockerize import __description__, __program__, __version__
+from dockerize.dockerize import Dockerize, symlink_options
 
 
 LOG = logging.getLogger(__name__)

--- a/dockerize/main.py
+++ b/dockerize/main.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 from __future__ import absolute_import,print_function
 

--- a/setup.py
+++ b/setup.py
@@ -1,23 +1,49 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+from dockerize import __description__, __program__, __version__
 from setuptools import setup, find_packages
-from dockerize import __version__
 
 
 def read(path):
-    with open(path) as fd:
-        return fd.read().splitlines()
+    '''Return contents of file as text.'''
+    with open(path) as f:
+        return f.read()
+
 
 setup(
-    name='dockerize',
+    name=__program__,
     version=__version__,
+    author='Lars Kellogg-Stedman',
+    author_email='lars@oddbit.com',
+    description=__description__,
+    long_description=read('README.rst'),
+    url='https://github.com/larsks/dockerize',
+    # license='GPLv3',
+    keywords=['Docker'],
     packages=find_packages(),
-    install_requires=read('requirements.txt'),
+    install_requires=read('requirements.txt').splitlines(),
     package_data={'dockerize': ['templates/*']},
     entry_points={
         'console_scripts': [
             'dockerize = dockerize.main:main'
         ]
-    }
+    },
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'Environment :: Console',
+        'Intended Audience :: Developers',
+        'Intended Audience :: End Users/Desktop',
+        'Intended Audience :: Information Technology',
+        'Intended Audience :: System Administrators',
+        # 'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+        'Natural Language :: English',
+        'Operating System :: POSIX',
+        'Operating System :: POSIX :: Linux',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3',
+        'Topic :: System',
+        'Topic :: System :: Systems Administration',
+        'Topic :: Utilities'
+    ]
 )

--- a/setup.py
+++ b/setup.py
@@ -5,14 +5,15 @@ from setuptools import setup, find_packages
 from dockerize import __version__
 
 with open('requirements.txt') as fd:
-    setup(name='dockerize',
-          version=__version__,
-          packages=find_packages(),
-          install_requires=fd.readlines(),
-          package_data={'dockerize': ['templates/*']},
-          entry_points={
-              'console_scripts': [
-                  'dockerize = dockerize.main:main',
-              ],
-          }
-          )
+    setup(
+        name='dockerize',
+        version=__version__,
+        packages=find_packages(),
+        install_requires=fd.readlines(),
+        package_data={'dockerize': ['templates/*']},
+        entry_points={
+            'console_scripts': [
+                'dockerize = dockerize.main:main'
+            ]
+        }
+    )

--- a/setup.py
+++ b/setup.py
@@ -4,16 +4,20 @@
 from setuptools import setup, find_packages
 from dockerize import __version__
 
-with open('requirements.txt') as fd:
-    setup(
-        name='dockerize',
-        version=__version__,
-        packages=find_packages(),
-        install_requires=fd.readlines(),
-        package_data={'dockerize': ['templates/*']},
-        entry_points={
-            'console_scripts': [
-                'dockerize = dockerize.main:main'
-            ]
-        }
-    )
+
+def read(path):
+    with open(path) as fd:
+        return fd.read().splitlines()
+
+setup(
+    name='dockerize',
+    version=__version__,
+    packages=find_packages(),
+    install_requires=read('requirements.txt'),
+    package_data={'dockerize': ['templates/*']},
+    entry_points={
+        'console_scripts': [
+            'dockerize = dockerize.main:main'
+        ]
+    }
+)

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,6 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
 from setuptools import setup, find_packages
 from dockerize import __version__
 


### PR DESCRIPTION
Here's an outline of the changes:
- Add requirements.txt to MANIFEST.in so that it will be included during packaging. It was previously unable to uninstall in package form.
- Convert README.md to README.rst with `pandoc` (PyPi only supports reStructedText).
- Force absolute imports everywhere. Was previously seeing the following error in Python 3:
  
  ```
  Traceback (most recent call last):
    File "/home/user/.local/bin/dockerize", line 7, in <module>
      from dockerize.main import main
    File "/home/user/.local/lib/python3.4/site-packages/dockerize/main.py", line 11, in <module>
      from dockerize.dockerize import Dockerize, symlink_options
    File "/home/user/.local/lib/python3.4/site-packages/dockerize/dockerize.py", line 16, in <module>
      from depsolver import DepSolver
  ImportError: No module named 'depsolver'
  ```
- Populate `setup` configuration.
- Use `argparse`'s version action.
- Add usage message to `--help`.
- Include installation instructions in README.rst.
- Follow PEP8 style guide as much as possible.
- Use semantic versioning (e.g. 0.0.1)

As far as I can tell, it should be ready to upload to PyPi. However I haven't tested it yet as I didn't want to register the package and prevent you from doing so. You'd probably want to upload it to the PyPi test server to ensure everything is functional. Documentation is prone to break if there are any errors in README.rst. Also note that you may want to select a LICENSE.
