### PR TITLE
Support python2 and python3

### DIFF
--- a/dockerize/depsolver.py
+++ b/dockerize/depsolver.py
@@ -57,9 +57,11 @@ class ELFFile(dict):
     def section(self, name):
         '''Return the raw content of the named section from the ELF file.'''
         section = self[name]
-        with open(self.path) as fde:
+        with open(self.path, 'rb') as fde:
             fde.seek(int(section.offset, base=16))
             data = fde.read(int(section.size, base=16))
+            if type(data) is bytes:
+              data = data.decode('utf-8')
             return data
 
     def interpreter(self):
@@ -82,11 +84,13 @@ class DepSolver(object):
         # to produce the list of library dependencies.
         try:
             elf = ELFFile(path)
-            interp = elf.interpreter()
         except ValueError:
             LOG.debug('%s is not a dynamically linked ELF binary (ignoring)',
                       path)
             return
+
+        try:
+            interp = elf.interpreter()
         except KeyError:
             LOG.debug('%s does not have a .interp section',
                       path)

--- a/dockerize/depsolver.py
+++ b/dockerize/depsolver.py
@@ -41,6 +41,8 @@ class ELFFile(dict):
             out = subprocess.check_output(
                 ['objdump', '-h', self.path],
                 stderr=subprocess.STDOUT).decode('utf8')
+            if type(out) is bytes:
+              out = out.decode("utf-8")
         except subprocess.CalledProcessError:
             raise ValueError(self.path)
 
@@ -92,6 +94,8 @@ class DepSolver(object):
 
         self.deps.add(interp)
         out = subprocess.check_output([interp, '--list', path])
+        if type(out) is bytes:
+          out = out.decode("utf-8")
 
         for line in out.splitlines():
             for exp in RE_DEPS:


### PR DESCRIPTION
In python 2.x, subprocess.check_output returns a string.
In python 3.x, subprocess.check_output returns an object of type <class 'bytes'>

This PR supports both cases so dockerize can run with python 2 or python 3.