### PR TITLE
enable support for other container image building tools

### DIFF
--- a/dockerize/dockerize.py
+++ b/dockerize/dockerize.py
@@ -36,10 +36,20 @@ class Dockerize(object):
                  entrypoint=None,
                  targetdir=None,
                  tag=None,
+                 container=None,
+                 buildcmd=None,
                  symlinks=SymlinkOptions.PRESERVE,
                  build=True):
 
         self.docker = {}
+        if container:
+            self.docker['container'] = container
+        else:
+            self.docker['container'] = 'docker'
+        if buildcmd:
+            self.docker['buildcmd'] = buildcmd
+        else:
+            self.docker['buildcmd'] = 'build'
         if cmd:
             self.docker['cmd'] = json.dumps(shlex.split(cmd))
             LOG.debug('CMD: %s', self.docker['cmd'])
@@ -225,8 +235,15 @@ class Dockerize(object):
                 self.copy_file(srcitem, dst)
 
     def build_image(self):
-        LOG.info('building Docker image')
-        cmd = ['docker', 'build']
+        if self.docker['buildcmd']:
+            buildcmd = self.docker['buildcmd']
+        else:
+            buildcmd = 'build'
+        if self.docker['container']:
+            cmd = [self.docker["container"], buildcmd]
+        else:
+            cmd = ['docker', 'build']
+        LOG.info('building Docker image using %s --%s', cmd[0], cmd[1])
         if 'tag' in self.docker:
             cmd += ['-t', self.docker['tag']]
 

--- a/dockerize/dockerize.py
+++ b/dockerize/dockerize.py
@@ -36,20 +36,15 @@ class Dockerize(object):
                  entrypoint=None,
                  targetdir=None,
                  tag=None,
-                 container=None,
+                 runtime=None,
                  buildcmd=None,
                  symlinks=SymlinkOptions.PRESERVE,
                  build=True):
 
         self.docker = {}
-        if container:
-            self.docker['container'] = container
-        else:
-            self.docker['container'] = 'docker'
-        if buildcmd:
-            self.docker['buildcmd'] = buildcmd
-        else:
-            self.docker['buildcmd'] = 'build'
+        self.docker['runtime'] = runtime if runtime else 'docker'
+        self.docker['buildcmd'] = buildcmd if buildcmd else 'build'
+
         if cmd:
             self.docker['cmd'] = json.dumps(shlex.split(cmd))
             LOG.debug('CMD: %s', self.docker['cmd'])
@@ -235,18 +230,11 @@ class Dockerize(object):
                 self.copy_file(srcitem, dst)
 
     def build_image(self):
-        if self.docker['buildcmd']:
-            buildcmd = self.docker['buildcmd']
-        else:
-            buildcmd = 'build'
-        if self.docker['container']:
-            cmd = [self.docker["container"], buildcmd]
-        else:
-            cmd = ['docker', 'build']
-        LOG.info('building Docker image using %s --%s', cmd[0], cmd[1])
+        cmd = [self.docker['runtime'], self.docker['buildcmd']]
         if 'tag' in self.docker:
             cmd += ['-t', self.docker['tag']]
-
         cmd += [self.targetdir]
+
+        LOG.info('building Docker image using "%s"', ' '.join(cmd))
 
         subprocess.check_call(cmd)

--- a/dockerize/main.py
+++ b/dockerize/main.py
@@ -63,6 +63,12 @@ def parse_args():
                         action='store_true',
                         help='Add common file manipulation tools')
 
+    group = parser.add_argument_group('Container options')
+    parser.add_argument('--container', '-T',
+                        help='Set container engine for building')
+    parser.add_argument('--buildcmd', '-b',
+                        help='Set command for building')
+
     group = parser.add_argument_group('Logging options')
     group.add_argument('--verbose',
                        action='store_const',
@@ -100,6 +106,8 @@ def main():
         args.entrypoint = args.paths[0]
 
     app = Dockerize(cmd=args.cmd,
+                    container=args.container,
+                    buildcmd=args.buildcmd,
                     entrypoint=args.entrypoint,
                     tag=args.tag,
                     targetdir=args.output_dir,

--- a/dockerize/main.py
+++ b/dockerize/main.py
@@ -64,10 +64,12 @@ def parse_args():
                         help='Add common file manipulation tools')
 
     group = parser.add_argument_group('Container options')
-    parser.add_argument('--container', '-T',
-                        help='Set container engine for building')
-    parser.add_argument('--buildcmd', '-b',
-                        help='Set command for building')
+    parser.add_argument('--runtime', '-R',
+                        help='Set container engine for building',
+                        default='docker')
+    parser.add_argument('--buildcmd', '-B',
+                        help='Set command for building',
+                        default='build')
 
     group = parser.add_argument_group('Logging options')
     group.add_argument('--verbose',
@@ -106,7 +108,7 @@ def main():
         args.entrypoint = args.paths[0]
 
     app = Dockerize(cmd=args.cmd,
-                    container=args.container,
+                    runtime=args.runtime,
                     buildcmd=args.buildcmd,
                     entrypoint=args.entrypoint,
                     tag=args.tag,


### PR DESCRIPTION
pull request for #23 
tested with podman and buildah
```
indy@localhost:~$ dockerize --debug -t sed:buster-latest /usr/bin/sed
DEBUG:dockerize.dockerize:ENTRYPOINT: ["/usr/bin/sed"]
DEBUG:dockerize.dockerize:tag: sed:buster-latest
INFO:dockerize.dockerize:start build process
INFO:dockerize.dockerize:copying file /usr/bin/sed to /usr/bin/sed
INFO:dockerize.dockerize:running: ['rsync', '-a', '--copy-unsafe-links', '/usr/bin/sed', '/tmp/dockerize1aunlvf7/usr/bin/sed']
INFO:dockerize.depsolver:getting dependencies for /tmp/dockerize1aunlvf7/usr/bin/sed
DEBUG:dockerize.depsolver:/tmp/dockerize1aunlvf7/usr/bin/sed is not a dynamically linked ELF binary (ignoring)
INFO:dockerize.dockerize:populating misc config files
INFO:dockerize.dockerize:generating Dockerfile
INFO:dockerize.dockerize:building Docker image using docker --build
STEP 1: FROM scratch
STEP 2: COPY . /
--> aa833fddba0
STEP 3: ENTRYPOINT ["/usr/bin/sed"]
STEP 4: COMMIT sed:buster-latest
--> 7c17fd58452
7c17fd58452857f2b43418b2e18cd2653584db4d4476dc8ced97dbe7b35627e7
indy@localhost:~$ dockerize --debug -T podman -t sed:buster-latest /usr/bin/sed
DEBUG:dockerize.dockerize:ENTRYPOINT: ["/usr/bin/sed"]
DEBUG:dockerize.dockerize:tag: sed:buster-latest
INFO:dockerize.dockerize:start build process
INFO:dockerize.dockerize:copying file /usr/bin/sed to /usr/bin/sed
INFO:dockerize.dockerize:running: ['rsync', '-a', '--copy-unsafe-links', '/usr/bin/sed', '/tmp/dockerize7p6u2vhy/usr/bin/sed']
INFO:dockerize.depsolver:getting dependencies for /tmp/dockerize7p6u2vhy/usr/bin/sed
DEBUG:dockerize.depsolver:/tmp/dockerize7p6u2vhy/usr/bin/sed is not a dynamically linked ELF binary (ignoring)
INFO:dockerize.dockerize:populating misc config files
INFO:dockerize.dockerize:generating Dockerfile
INFO:dockerize.dockerize:building Docker image using podman --build
STEP 1: FROM scratch
STEP 2: COPY . /
--> 1e99a43424d
STEP 3: ENTRYPOINT ["/usr/bin/sed"]
STEP 4: COMMIT sed:buster-latest
--> 67b20ab7374
67b20ab73745f1905e3503dcd7ca188b1de4a38d34d8999f68fe3791e05bba6c
indy@localhost:~$ dockerize --debug -T buildah -b build-using-dockerfile -t sed:buster-latest /usr/bin/sed
DEBUG:dockerize.dockerize:ENTRYPOINT: ["/usr/bin/sed"]
DEBUG:dockerize.dockerize:tag: sed:buster-latest
INFO:dockerize.dockerize:start build process
INFO:dockerize.dockerize:copying file /usr/bin/sed to /usr/bin/sed
INFO:dockerize.dockerize:running: ['rsync', '-a', '--copy-unsafe-links', '/usr/bin/sed', '/tmp/dockerize3z46951p/usr/bin/sed']
INFO:dockerize.depsolver:getting dependencies for /tmp/dockerize3z46951p/usr/bin/sed
DEBUG:dockerize.depsolver:/tmp/dockerize3z46951p/usr/bin/sed is not a dynamically linked ELF binary (ignoring)
INFO:dockerize.dockerize:populating misc config files
INFO:dockerize.dockerize:generating Dockerfile
INFO:dockerize.dockerize:building Docker image using buildah --build-using-dockerfile
STEP 1: FROM scratch
STEP 2: COPY . /
STEP 3: ENTRYPOINT ["/usr/bin/sed"]
STEP 4: COMMIT sed:buster-latest
Getting image source signatures
Copying blob 20a36c62c7b8 done
Copying config 293b68e796 done
Writing manifest to image destination
Storing signatures
--> 293b68e7965
293b68e79650933d93fe7821f143dbc5c6afc0a3aae0405ea96cbaf3eb482a20
indy@localhost:~$

```